### PR TITLE
Fix typos

### DIFF
--- a/conf/observer.conf
+++ b/conf/observer.conf
@@ -1,5 +1,5 @@
 standalone: false
 protocol-server.network-id: dockernet
-casper.shard-name: sandbox_1
+casper.shard-name: ""
 casper.fork-choice-stale-threshold: 20 minutes
 casper.fork-choice-check-if-stale-interval: 16 minutes

--- a/observer.yml
+++ b/observer.yml
@@ -5,16 +5,16 @@ services:
     user: root
     networks:
       - rchain-net
-    container_name: rnode.observer
+    container_name: rnode.readonly
     ports:
-      - "40401:40401"
+      - "30401:30401"
     command:
       [
         "run",
         "--bootstrap=rnode://22457f2b426a31b5b497376ed4341a2092d5c6cc@$BOOTSTRAP_HOST?protocol=40400&discovery=40404",
         "--host=$READONLY_HOST",
         "--allow-private-addresses",
-        "--synchrony-constraint-threshold=$SYNCHRONY_CONSTRAINT_THREDHOLD",
+        "--synchrony-constraint-threshold=$SYNCHRONY_CONSTRAINT_THRESHOLD",
       ]
     volumes:
       - ./data/observer:/var/lib/rnode/


### PR DESCRIPTION
1. Make observer the same shard name with validators
2. Change port of observer to not clash with validator
3. Fix typo in observer config and container name